### PR TITLE
updated all Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,64 +1,132 @@
-# Change Log
+# Changelog
 
-## 0.0.2 [30-11-2023]
+<!-- markdownlint-configure-file
+{
+  "MD024": { "siblings_only": true }
+}
+-->
 
-* Fixed `README.md`, `package.json`, `CHANGELOG.md`
-  
-## 0.0.1 [30-11-2023]
+All notable changes to this project will be documented in this file.
 
-* Fixed some bugs I encountered due to updates and changes in the way Symfony works.
-* The `symfony/flex` dependency has been added to work with Shopware 6.
-* The `--show-private` command has been replaced with `--show-hidden` due to Symfony changes
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [unreleased]
+
+### Added
+
+- `src/` folder which contains the source Typescript file
+- `.vscodeignore` so the overhead isn't Packaged in the Plugin
+- `.gitattributes` from the Original Project
+- `.devcontainer/` added this Dev Enviroment
+- `.vscode/` added VSCode config
+- `.github/` added dependabot config
+- `"@vscode/vsce": "^2.24.0"`, `"@vscode/test-electron": "^2.3.0"` to dev Dependencys
+- Added these scripts to `package.json`:
+  - `"vscode:package": "vsce package"`
+  - `"vscode:prepublish": "yarn run compile"`
+  - `"compile": "tsc -p ./"`
+  - `"watch": "tsc -watch -p ./"`
+  - `"postinstall": "yarn ./node_modules/vscode/bin/install"`
+  - `"test": "yarn run compile && yarn ./node_modules/vscode/bin/test"`
+  - `"publish": "vsce publish"`
+
+### Changed
+
+- recreated `node_modules` to clear old not used dependencys
+- `.vsixmanifest`: Extention Version to 0.0.4; changed minimal VSCode engine to ^1.76.0
+- Keep a Changelog version to [1.1.0](https://keepachangelog.com/en/1.1.0/)
+- updated dev dependency Versions to:
+  - `"@types/mocha": "^10.0.1"`
+  - `"@types/node": "^18.11.9"`
+  - `"@types/vscode": "^1.76.0"`
+  - `"typescript": "^5.4.3"`
+
+### Fixed
+
+- Markdown violations in `ENVIROMENTS.md`
+- Links in `README.md` to point to the new Repo
+- `CONTRIBUTING.md` fixed links and code blocks
+
+## [0.0.3] - 2024-01-17
+
+### Changed
+
+- The Container Provider now runs: `["debug:container", "--show-hidden"]` and `["debug:container"]`
+
+## [0.0.2] - 2023-11-30
+
+### Fixed
+
+- Issues in `README.md`, `package.json`, `CHANGELOG.md`
+
+## [0.0.1] - 2023-11-30
+
+### Added
+
+- The `symfony/flex` dependency to work with Shopware 6.
+
+### Fixed
+
+- Some bugs encountered due to updates and changes in the way Symfony works.
+
+### Changed
+
+- The `--show-private` command has been replaced with `--show-hidden` due to Symfony changes
+
+---
+
+## **TheNouillet changelog from Original version. Fork starts at 0.0.1**
 
 ## 1.0.2 [02-27-2019]
 
-* Fixed the extension not starting at all
+- Fixed the extension not starting at all
 
 ## 1.0.1 [02-26-2019]
 
-* [#31](https://github.com/TheNouillet/symfony-vscode/pull/31) Fix parsing of files not working on Windows (thank you [smertelny](https://github.com/smertelny) !)
-* Fix of command console failure when the console output has comments in it
-* Fix PHP parsing not working
+- [#31](https://github.com/TheNouillet/symfony-vscode/pull/31) Fix parsing of files not working on Windows (thank you [smertelny](https://github.com/smertelny) !)
+- Fix of command console failure when the console output has comments in it
+- Fix PHP parsing not working
 
 ## 1.0.0 [02-25-2019]
 
-* Added a "Include PHPDoc tag for Symfony service" code action
-  * This code action allows you to include a `@var` PHPDoc tag on the line above a recognized service name
-  * This acts as a way to provide autocompletion of a service obtained via a ContainerInterface object (such as `$this->get('logger')` in a controller for example)
-* Added a "Go to definition" on services in YAML, XML and PHP files
-  * PHP files are now parsed
-* Container elements and PHP files are now cached
-  * Startup is now way faster on existing projects
-  * Commands and file modification invalidates caches.
-* Console command calls are now asynchronous
-  * The extension usage with Docker or others shell-based environments has been changed, via the addition of `shellExecutable` and `shellCommand` parameters.
-* Added a search functionnality on services, routes and parameters views.
-* Added the `parametersFilters` setting to filter out parameters, such as classes.
-* Added the `routesFilters` setting to filter out routes, such as Assetic routes.
-  * Let know in the repository issues if default filters aren't pertinent enough ! I made them according to my work habbits, but each project is different.
-* Errors messages now display only once when refreshing services, routes and parameters (i.e. at extension startup or configuration file modification)
+- Added a "Include PHPDoc tag for Symfony service" code action
+  - This code action allows you to include a `@var` PHPDoc tag on the line above a recognized service name
+  - This acts as a way to provide autocompletion of a service obtained via a ContainerInterface object (such as `$this->get('logger')` in a controller for example)
+- Added a "Go to definition" on services in YAML, XML and PHP files
+  - PHP files are now parsed
+- Container elements and PHP files are now cached
+  - Startup is now way faster on existing projects
+  - Commands and file modification invalidates caches.
+- Console command calls are now asynchronous
+  - The extension usage with Docker or others shell-based environments has been changed, via the addition of `shellExecutable` and `shellCommand` parameters.
+- Added a search functionnality on services, routes and parameters views.
+- Added the `parametersFilters` setting to filter out parameters, such as classes.
+- Added the `routesFilters` setting to filter out routes, such as Assetic routes.
+  - Let know in the repository issues if default filters aren't pertinent enough ! I made them according to my work habbits, but each project is different.
+- Errors messages now display only once when refreshing services, routes and parameters (i.e. at extension startup or configuration file modification)
 
 ## 0.0.3 [08-06-2018]
 
-* Added aucompletion of public services in PHP files
-* Added the parameter view to display parameters of the Symfony container.
-* Added aucompletion of parameters in YAML files
-* Added class name on hover on a known service id in YAML and PHP files.
-* Added the `enableFileWatching` setting to enable or disable file watching.
-* Added the `servicesFilters` to improve autocompletion pertinence.
-* Added the "Toggle class/id display for services" command to switch between Id and class name display on the services view.
-* Added the "Toggle path/id display for routes" command to switch between Id and paths display on the routes view.
-  * These two commands are available via buttons on the side of the two views.
+- Added aucompletion of public services in PHP files
+- Added the parameter view to display parameters of the Symfony container.
+- Added aucompletion of parameters in YAML files
+- Added class name on hover on a known service id in YAML and PHP files.
+- Added the `enableFileWatching` setting to enable or disable file watching.
+- Added the `servicesFilters` to improve autocompletion pertinence.
+- Added the "Toggle class/id display for services" command to switch between Id and class name display on the services view.
+- Added the "Toggle path/id display for routes" command to switch between Id and paths display on the routes view.
+  - These two commands are available via buttons on the side of the two views.
 
 ## 0.0.2 [08-04-2018]
 
-* Added autocompletion of services in YAML files
-* Added the `detectCwd` setting to help with Symfony projects on Docker
-* Added more logging of errors
-  * Added the `showConsoleErrors` setting to hide errors from the Symfony console
-* Added progress indicator on the status bar
-* Added buttons to the side of TreeViews to re-sync the extension and Symfony.
-* Added class name for services aliases
+- Added autocompletion of services in YAML files
+- Added the `detectCwd` setting to help with Symfony projects on Docker
+- Added more logging of errors
+  - Added the `showConsoleErrors` setting to hide errors from the Symfony console
+- Added progress indicator on the status bar
+- Added buttons to the side of TreeViews to re-sync the extension and Symfony.
+- Added class name for services aliases
 
 ## 0.0.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,17 +26,17 @@ Note that if your Symfony app is not running on a conventionnal installation (Do
 To contribute to this extension, you must have the following tools :
 
 * Git (obviously)
-* NodeJS (>= 8.11)
-* npm (>= 5.6)
+* Node (>= v20.12.0)
+* yarn (>= 1.22.19)
 
 If you want to have a better understanding of extension authoring, [the documentation is your first stop](https://code.visualstudio.com/api).
 
 ### Installation
 
 ```bash
-git clone https://github.com/TheNouillet/symfony-vscode.git
-npm install --no-save
-npm run compile
+git clone https://github.com/SplasHmiCH/splashmich.symfony-vscode.git
+yarn install
+yarn run compile
 ```
 
 ### Watching
@@ -44,7 +44,7 @@ npm run compile
 For developpement, it's easier to watch the files with :
 
 ```bash
-npm run watch
+yarn run watch
 ```
 
 ### Creating the VSIX file
@@ -52,13 +52,13 @@ npm run watch
 VSIX file allows you to install the extension on VSCode. For this, you have to install the `vsce` utility :
 
 ```bash
-npm install -g vsce
+yarn install
 ```
 
 To create a VSIX file, you can use this command :
 
 ```bash
-vsce package
+yarn vscode:package
 ```
 
 Make sure that your dependencies are up-to-date before packaging the extension.

--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -12,7 +12,6 @@ You have to change the PHP path if you're working on Windows :
 }
 ```
 
-
 ## Docker
 
 [Docker](https://www.docker.com/) is used to perform containerization.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ I fixed some bugs I encountered due to updates and changes in the way Symfony wo
 
 This extension aims to help developing Symfony**3**+ projects, by providing basic autocompletion and visualization of the Symfony container.
 
-![Autocomplete](https://github.com/TheNouillet/symfony-vscode/raw/master/media/autocomplete.gif)
+![Autocomplete](https://github.com/SplasHmiCH/splashmich.symfony-vscode/blob/main/media/autocomplete.gif?raw=true)
 
 ## Features
 
@@ -17,7 +17,7 @@ This extension provides the following features :
 * Go to implementation of a service
 * A custom view to visualize the current project container, with services, routes and parameters
 
-![Debug view](https://github.com/TheNouillet/symfony-vscode/raw/master/media/view.gif)
+![Debug view](https://github.com/SplasHmiCH/splashmich.symfony-vscode/blob/main/media/view.gif?raw=true)
 
 ## How does it works ?
 
@@ -44,15 +44,15 @@ Here are the settings that can be overridden for convenience :
 
 ## Various environments
 
-If your Symfony app is not running on a conventional installation (for example, you are running a Symfony app on a Docker container), you can find different configuration recipes [here](https://github.com/TheNouillet/symfony-vscode/blob/master/ENVIRONMENTS.md).
+If your Symfony app is not running on a conventional installation (for example, you are running a Symfony app on a Docker container), you can find different configuration recipes [here](https://github.com/SplasHmiCH/splashmich.symfony-vscode/blob/main/ENVIRONMENTS.md).
 
 ## Contribution
 
-If you want to contribute to this extension, everything you want to know is [here](https://github.com/TheNouillet/symfony-vscode/blob/master/CONTRIBUTING.md).
+If you want to contribute to this extension, everything you want to know is [here](https://github.com/SplasHmiCH/splashmich.symfony-vscode/blob/main/CONTRIBUTING.md).
 
 ## Release Notes
 
-See [the changelog](https://github.com/TheNouillet/symfony-vscode/blob/master/CHANGELOG.md) for releases notes.
+See [the changelog](https://github.com/SplasHmiCH/splashmich.symfony-vscode/blob/main/CHANGELOG.md) for releases notes.
 
 ## Acknowledgments
 

--- a/package.json
+++ b/package.json
@@ -296,7 +296,13 @@
         "typescript": "^5.4.3"
     },
     "scripts": {
-        "package": "vsce package"
+        "vscode:package": "vsce package",
+        "vscode:prepublish": "yarn run compile",
+        "compile": "tsc -p ./",
+        "watch": "tsc -watch -p ./",
+        "postinstall": "yarn ./node_modules/vscode/bin/install",
+        "test": "yarn run compile && yarn ./node_modules/vscode/bin/test",
+        "publish": "vsce publish"
     },
     "dependencies": {
         "graceful-fs": "^4.1.15",


### PR DESCRIPTION
### Added

- `src/` folder which contains the source Typescript file
- `.vscodeignore` so the overhead isn't Packaged in the Plugin
- `.gitattributes` from the Original Project
- `.devcontainer/` added this Dev Enviroment
- `.vscode/` added VSCode config
- `.github/` added dependabot config
- `"@vscode/vsce": "^2.24.0"`, `"@vscode/test-electron": "^2.3.0"` to dev Dependencys
- Added these scripts to `package.json`:
  - `"vscode:package": "vsce package"`
  - `"vscode:prepublish": "yarn run compile"`
  - `"compile": "tsc -p ./"`
  - `"watch": "tsc -watch -p ./"`
  - `"postinstall": "yarn ./node_modules/vscode/bin/install"`
  - `"test": "yarn run compile && yarn ./node_modules/vscode/bin/test"`
  - `"publish": "vsce publish"`

### Changed

- recreated `node_modules` to clear old not used dependencys
- `.vsixmanifest`: Extention Version to 0.0.4; changed minimal VSCode engine to ^1.76.0
- Keep a Changelog version to [1.1.0](https://keepachangelog.com/en/1.1.0/)
- updated dev dependency Versions to:
  - `"@types/mocha": "^10.0.1"`
  - `"@types/node": "^18.11.9"`
  - `"@types/vscode": "^1.76.0"`
  - `"typescript": "^5.4.3"`

### Fixed

- Markdown violations in `ENVIROMENTS.md`
- Links in `README.md` to point to the new Repo
- `CONTRIBUTING.md` fixed links and code blocks